### PR TITLE
v1.0.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,11 @@ inputs:
   project:
     description: Name of the project
     required: true
-    default: contractapp
+    default: lup
   repo-category:
     description: Stack Category of the project (like Web, Backend, etc)
     required: true
-    default: Web
+    default: Backend
 
 # Define your outputs here.
 outputs:

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -1,0 +1,14 @@
+const NOTION_TO_GITHUB_USERS: { [name: string]: string } = {
+  'Kaio Gabriel Souza Rozini': 'KaioGabrielSouzaRozini',
+  'Pedro Epifanio': 'pedroepif',
+  'Kelly Martina': 'kellymartina',
+  'Igor Benedet': 'IgorB20',
+  Lucas: 'lucas-oruncode',
+  Mathgobbo: 'Mathgobbo'
+}
+
+export const getGithubUserFromNotionUser = (notionUser: string) => {
+  const user = NOTION_TO_GITHUB_USERS[notionUser]
+  if (!user) return 'Unknown'
+  return user
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
 } from './lib/notion.js'
 import { DatabaseObjectResponse } from '@notionhq/client/build/src/api-endpoints.js'
 import { PageProperties } from './types/notion.js'
+import { getGithubUserFromNotionUser } from './lib/map.js'
 
 type SearchResult = {
   title: { plain_text: string }[]
@@ -54,7 +55,7 @@ export async function run(): Promise<void> {
       const idObject = properties['ID'].unique_id
       const id = idObject.prefix + '-' + idObject.number
       const developers = properties['Assign'].people
-        .map((person) => person?.name)
+        .map((person) => '@' + getGithubUserFromNotionUser(person?.name))
         .join(', ')
 
       tasksCategories.push(properties['Category'].select?.name)
@@ -65,20 +66,21 @@ export async function run(): Promise<void> {
 
     const changelog = `## What's new \n ${doneTasks.join('\n')}`
 
-    const { newVersion, releaseId } = await createGithubRelease({
-      categories: tasksCategories,
-      changeLog: changelog
-    })
+    // const { newVersion, releaseId } = await createGithubRelease({
+    //   categories: tasksCategories,
+    //   changeLog: changelog
+    // })
 
-    for (const page of response.results)
-      await updateNotionPageVersion({
-        newVersion,
-        pageId: page.id
-      })
+    // for (const page of response.results)
+    //   await updateNotionPageVersion({
+    //     newVersion,
+    //     pageId: page.id
+    //   })
 
-    await publishGithubRelease(releaseId)
+    // await publishGithubRelease(releaseId)
 
-    core.setOutput('new-version', newVersion)
+    core.setOutput('new-version', changelog)
+    // core.setOutput('new-version', newVersion)
   } catch (error) {
     // Fail the workflow run if an error occurs
     if (error instanceof Error) core.setFailed(error.message)


### PR DESCRIPTION
feat: update default project and repo-category, add map.ts for user mapping

Updated the default project name to lup and the repo-category to Backend in action.yml. Added map.ts file for mapping Notion users to GitHub usernames and integrated this mapping into the main function in main.ts. Commented out code related to creating and publishing GitHub releases and updated core.setOutput usage.